### PR TITLE
Add ramping info display and update smooth start UI

### DIFF
--- a/resources/lang/ar_AR.xml
+++ b/resources/lang/ar_AR.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">اختار اللغة:</translation>
     <translation key="language_saved">تم حفظ اللغة</translation>
     <translation key="save_button_text">حفظ</translation>
-    <translation key="enable_smooth_start">بداية سلسة</translation>
+    <translation key="smooth_start">بداية تدريجية</translation>
+    <translation key="smooth_start_info">تسارع تدريجي</translation>
     
     <!-- ================= -->
     <!-- معلومات الإصدار -->

--- a/resources/lang/da_DK.xml
+++ b/resources/lang/da_DK.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">Vælg sprog:</translation>
     <translation key="language_saved">Sprog er gemt</translation>
     <translation key="save_button_text">Gem</translation>
-    <translation key="enable_smooth_start">Blød start</translation>
+    <translation key="smooth_start">Blød start</translation>
+    <translation key="smooth_start_info">Gradvis acceleration</translation>
     
     <!-- ================= -->
     <!-- VERSIONOPLYSNINGER -->

--- a/resources/lang/de_DE.xml
+++ b/resources/lang/de_DE.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">Sprache auswählen:</translation>
     <translation key="language_saved">Sprache wurde gespeichert</translation>
     <translation key="save_button_text">Speichern</translation>
-    <translation key="enable_smooth_start">Sanfter Start</translation>
+    <translation key="smooth_start">Sanfter Start</translation>
+    <translation key="smooth_start_info">Noten starten mit sanfter Geschwindigkeit.</translation>
     
     <!-- ================= -->
     <!-- VERSIONSINFORMATION -->

--- a/resources/lang/en_EN.xml
+++ b/resources/lang/en_EN.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">Select language:</translation>
     <translation key="language_saved">Language has been saved</translation>
     <translation key="save_button_text">Save</translation>
-    <translation key="enable_smooth_start">Smooth Start</translation>
+    <translation key="smooth_start">Smooth Start</translation>
+    <translation key="smooth_start_info">Note acceleration</translation>
     
     <!-- ================= -->
     <!-- VERSION INFORMATION -->

--- a/resources/lang/en_US.xml
+++ b/resources/lang/en_US.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">Select Language:</translation>
     <translation key="language_saved">Language saved</translation>
     <translation key="save_button_text">Save</translation>
-    <translation key="enable_smooth_start">Smooth Start</translation>
+    <translation key="smooth_start">Smooth Start</translation>
+    <translation key="smooth_start_info">Note acceleration</translation>
     
     <!-- ================= -->
     <!-- VERSION INFORMATION -->

--- a/resources/lang/es_ES.xml
+++ b/resources/lang/es_ES.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">Seleccionar idioma:</translation>
     <translation key="language_saved">Idioma guardado</translation>
     <translation key="save_button_text">Guardar</translation>
-    <translation key="enable_smooth_start">Inicio suave</translation>
+    <translation key="smooth_start">Inicio suave</translation>
+    <translation key="smooth_start_info">Aceleración gradual</translation>
     
     <!-- ================= -->
     <!-- INFORMACIÓN DE VERSIÓN -->

--- a/resources/lang/fr_FR.xml
+++ b/resources/lang/fr_FR.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">Sélectionner la langue :</translation>
     <translation key="language_saved">Langue enregistrée</translation>
     <translation key="save_button_text">Enregistrer</translation>
-    <translation key="enable_smooth_start">Démarrage en douceur</translation>
+    <translation key="smooth_start">Démarrage doux</translation>
+    <translation key="smooth_start_info">Accélération progressive</translation>
     
     <!-- ================= -->
     <!-- INFORMATION SUR LA VERSION -->

--- a/resources/lang/id_ID.xml
+++ b/resources/lang/id_ID.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">Pilih bahasa:</translation>
     <translation key="language_saved">Bahasa telah disimpan</translation>
     <translation key="save_button_text">Simpan</translation>
-    <translation key="enable_smooth_start">Mulai halus</translation>
+    <translation key="smooth_start">Mulai Bertahap</translation>
+    <translation key="smooth_start_info">Akselerasi bertahap</translation>
     
     <!-- ================= -->
     <!-- INFORMASI VERSI -->

--- a/resources/lang/it_IT.xml
+++ b/resources/lang/it_IT.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">Seleziona lingua:</translation>
     <translation key="language_saved">Lingua salvata</translation>
     <translation key="save_button_text">Salva</translation>
-    <translation key="enable_smooth_start">Avvio graduale</translation>
+    <translation key="smooth_start">Avvio graduale</translation>
+    <translation key="smooth_start_info">Accelerazione graduale</translation>
     
     <!-- ================= -->
     <!-- INFORMAZIONI SULLA VERSIONE -->

--- a/resources/lang/ja_JA.xml
+++ b/resources/lang/ja_JA.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">言語を選択：</translation>
     <translation key="language_saved">言語が保存されました</translation>
     <translation key="save_button_text">保存</translation>
-    <translation key="enable_smooth_start">スムーズスタート</translation>
+    <translation key="smooth_start">スムーズスタート</translation>
+    <translation key="smooth_start_info">徐々な加速</translation>
     
     <!-- ================= -->
     <!-- バージョン情報 -->

--- a/resources/lang/ko_KR.xml
+++ b/resources/lang/ko_KR.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">언어 선택:</translation>
     <translation key="language_saved">언어가 저장되었습니다</translation>
     <translation key="save_button_text">저장</translation>
-    <translation key="enable_smooth_start">부드러운 시작</translation>
+    <translation key="smooth_start">부드러운 시작</translation>
+    <translation key="smooth_start_info">점진적 가속</translation>
     
     <!-- ================= -->
     <!-- 버전 정보 -->

--- a/resources/lang/mg_MG.xml
+++ b/resources/lang/mg_MG.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">Misafidiana fiteny:</translation>
     <translation key="language_saved">Voavonjy ny fiteny</translation>
     <translation key="save_button_text">Tehirizo</translation>
-    <translation key="enable_smooth_start">Fanombohana malefaka</translation>
+    <translation key="smooth_start">Fanombohana moramora</translation>
+    <translation key="smooth_start_info">Hafainganana moramora</translation>
     
     <!-- ================= -->
     <!-- FAMPANDRAISANA NY VERSIONS -->

--- a/resources/lang/nl_NL.xml
+++ b/resources/lang/nl_NL.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">Kies taal:</translation>
     <translation key="language_saved">Taal is opgeslagen</translation>
     <translation key="save_button_text">Opslaan</translation>
-    <translation key="enable_smooth_start">Zachte start</translation>
+    <translation key="smooth_start">Zachte start</translation>
+    <translation key="smooth_start_info">Geleidelijke versnelling</translation>
     
     <!-- ================= -->
     <!-- VERSIE-INFORMATIE -->

--- a/resources/lang/pl_PL.xml
+++ b/resources/lang/pl_PL.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">Wybierz język:</translation>
     <translation key="language_saved">Język zapisany pomyślnie</translation>
     <translation key="save_button_text">Zapisz</translation>
-    <translation key="enable_smooth_start">Płynny start</translation>
+    <translation key="smooth_start">Płynny start</translation>
+    <translation key="smooth_start_info">Płynne przyspieszenie</translation>
     
     <!-- ================= -->
     <!-- INFORMACJE O WERSJI -->

--- a/resources/lang/pt_PT.xml
+++ b/resources/lang/pt_PT.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">Selecione o idioma:</translation>
     <translation key="language_saved">Idioma salvo com sucesso</translation>
     <translation key="save_button_text">Salvar</translation>
-    <translation key="enable_smooth_start">Início suave</translation>
+    <translation key="smooth_start">Início suave</translation>
+    <translation key="smooth_start_info">Aceleração gradual</translation>
     
     <!-- ================= -->
     <!-- INFORMAÇÃO DA VERSÃO -->

--- a/resources/lang/ru_RU.xml
+++ b/resources/lang/ru_RU.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">Выберите язык:</translation>
     <translation key="language_saved">Язык был сохранен</translation>
     <translation key="save_button_text">Сохранить</translation>
-    <translation key="enable_smooth_start">Плавный старт</translation>
+    <translation key="smooth_start">Плавный старт</translation>
+    <translation key="smooth_start_info">Плавное ускорение</translation>
     
     <!-- ================= -->
     <!-- ИНФОРМАЦИЯ О ВЕРСИИ -->

--- a/resources/lang/zh_ZH.xml
+++ b/resources/lang/zh_ZH.xml
@@ -42,7 +42,8 @@
     <translation key="select_language">选择语言：</translation>
     <translation key="language_saved">语言已保存</translation>
     <translation key="save_button_text">保存</translation>
-    <translation key="enable_smooth_start">平滑启动</translation>
+    <translation key="smooth_start">平滑启动</translation>
+    <translation key="smooth_start_info">渐进加速</translation>
     
     <!-- ================= -->
     <!-- 版本信息 -->


### PR DESCRIPTION
Introduces a new ramping info display for users when smooth start is disabled, with a configurable display count and updated window sizing logic. Refactors the smooth start toggle to a button, adds new translation keys for 'smooth_start' and 'smooth_start_info' in all supported languages, and updates error logging for playback. Bumps version to 2.3.5.