### PR TITLE
Add resource loader for PyInstaller compatibility

### DIFF
--- a/code/ProjectLyrica.py
+++ b/code/ProjectLyrica.py
@@ -16,6 +16,7 @@ from language_manager import LanguageManager, KeyboardLayoutManager
 from language_window import LanguageWindow
 from sky_checker import SkyChecker
 from music_player import MusicPlayer
+from resource_loader import resource_path
 
 logger = logging.getLogger("ProjectLyrica.ProjectLyrica")
 
@@ -28,7 +29,7 @@ EXPANDED_SIZE = (400, 455)
 FULL_SIZE = (400, 535)
 RAMPING_INFO_HEIGHT = 55
 MAX_RAMPING_INFO_DISPLAY = 6
-VERSION = "2.4.4"
+VERSION = "2.4.5"
 
 # -------------------------------
 # Music App
@@ -88,7 +89,7 @@ class MusicApp:
         try:
             self.root = ctk.CTk()
             self.root.title(LanguageManager.get("project_title"))
-            self.root.iconbitmap("resources/icons/icon.ico")
+            self.root.iconbitmap(resource_path("resources/icons/icon.ico"))
             self.root.protocol('WM_DELETE_WINDOW', self._shutdown)
             
             theme = ConfigManager.get_value("theme", "dark")

--- a/code/language_manager.py
+++ b/code/language_manager.py
@@ -8,6 +8,8 @@ import logging
 from tkinter import messagebox
 import traceback
 
+from resource_loader import resource_path
+
 logger = logging.getLogger("ProjectLyrica.LanguageManager")
 
 class LanguageManager:
@@ -35,7 +37,7 @@ class LanguageManager:
     @classmethod
     def _load_languages(cls):
         """Load available languages from configuration file."""
-        lang_file = Path('resources/config/lang.xml')
+        lang_file = Path(resource_path('resources/config/lang.xml'))
         try:
             if not lang_file.exists():
                 raise FileNotFoundError(f"Language config file not found: {lang_file}")
@@ -85,7 +87,7 @@ class LanguageManager:
         if lang_code in cls._translations:
             return cls._translations[lang_code]
         
-        lang_file = Path(f'resources/lang/{lang_code}.xml')
+        lang_file = Path(resource_path(f'resources/lang/{lang_code}.xml'))
         try:
             if not lang_file.exists():
                 raise FileNotFoundError(f"Translation file not found: {lang_file}")
@@ -221,7 +223,7 @@ class KeyboardLayoutManager:
         if layout_name in KeyboardLayoutManager._layout_cache:
             return KeyboardLayoutManager._layout_cache[layout_name]
             
-        file_path = Path(f'resources/layouts/{layout_name.lower()}.xml')
+        file_path = Path(resource_path(f'resources/layouts/{layout_name.lower()}.xml'))
         try:
             if not file_path.exists():
                 return {}

--- a/code/language_window.py
+++ b/code/language_window.py
@@ -5,6 +5,7 @@ import logging
 import customtkinter as ctk
 from tkinter import messagebox
 from language_manager import LanguageManager
+from resource_loader import resource_path
 
 logger = logging.getLogger("ProjectLyrica.LanguageWindow")
 
@@ -23,7 +24,7 @@ class LanguageWindow:
             root = ctk.CTk()
             root.title(LanguageManager.get('language_window_title'))
             root.geometry("400x200")
-            root.iconbitmap("resources/icons/icon.ico")
+            root.iconbitmap(resource_path("resources/icons/icon.ico"))
             
             languages = LanguageManager.get_languages()
             if not languages:

--- a/code/resource_loader.py
+++ b/code/resource_loader.py
@@ -1,0 +1,12 @@
+import sys
+import os
+from pathlib import Path
+
+def resource_path(relative_path):
+    """Get absolute path to resource, works for dev and for PyInstaller"""
+    if hasattr(sys, '_MEIPASS'):
+        base_path = sys._MEIPASS
+    else:
+        base_path = os.path.abspath(".")
+    
+    return os.path.join(base_path, relative_path)

--- a/code/sky_checker.py
+++ b/code/sky_checker.py
@@ -6,6 +6,7 @@ from tkinter import messagebox, filedialog
 from pathlib import Path
 from config_manager import ConfigManager
 from language_manager import LanguageManager
+from resource_loader import resource_path
 import logging
 import sys
 import os
@@ -27,10 +28,7 @@ class SkyChecker:
             root = ctk.CTk()
             root.title(LanguageManager.get('window_settings_title'))
             root.geometry("600x150")
-            try:
-                root.iconbitmap("resources/icons/icon.ico")
-            except Exception as e:
-                logger.warning(f"Could not load icon: {e}")
+            root.iconbitmap(resource_path("resources/icons/icon.ico"))
 
             saved = False
             example_path = "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Sky Children of the Light\\Sky.exe"


### PR DESCRIPTION
A new resource_loader module with a resource_path function has been introduced to correctly resolve resource file paths in both the development environment and PyInstaller environments. All references to resource files in ProjectLyrica.py, language_manager.py, language_window.py, and sky_checker.py have been updated to use resource_path, ensuring consistent access to icons and configuration files. The version has been increased to 2.4.5.

Only the exe is now required, along with the Songs folder under “Resource”; everything else is already included in the exe.